### PR TITLE
feat: add Isou provider

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -82,6 +82,10 @@ function registerBotCommands() {
 		(ctx) => TelegramService.callAdminModel(ctx, TelegramService.callPhindModel),
 	);
 	BOT.hears(
+		/^(isou):/gi,
+		(ctx) => TelegramService.callAdminModel(ctx, TelegramService.callIsouModel),
+	);
+	BOT.hears(
 		/^(pgpt|pgrok|po3|pclaude):/gi,
 		(ctx) => TelegramService.callAdminModel(ctx, TelegramService.callOpenWebUIModel),
 	);

--- a/src/config/KeyboardConfig.ts
+++ b/src/config/KeyboardConfig.ts
@@ -8,6 +8,7 @@ const adminCommandButtons = [
 	[
 		['Llama 4 Maverick', '/llama'],
 		['Phind', '/phind'],
+		['Isou', '/isou'],
 	],
 	[
 		['Copilot GPT 5 Mini', '/gpt'],
@@ -56,6 +57,7 @@ const userCommandButtons = [
 	[
 		['Phind', '/phind'],
 		['GPT OSS 120b', '/oss'],
+		['Isou', '/isou'],
 	],
 	[
 		['Pollinations', '/polli'],
@@ -71,7 +73,7 @@ const userCommandButtons = [
 	],
 	[
 		['Llama 4 Maverick', '/llama'],
-		['Copilot GPT 5 Mini', '/gpt']
+		['Copilot GPT 5 Mini', '/gpt'],
 	],
 	[['Limpar Histórico', '/clear']],
 ];
@@ -98,6 +100,7 @@ export const adminHelpMessage = `*Comandos inline*:
 \\- \`sql:\` mensagem \\- Gera sql com modelo __SQL Coder__
 \\- \`code:\` mensagem \\- Gera código com modelo __Deepseek Coder__
 \\- \`phind:\` mensagem \\- Faz uma pergunta usando o modelo __Phind__ com acesso web
+\\- \`isou:\` mensagem \\- Faz uma pergunta usando o modelo __Isou__ com acesso web
 \\- \`perplexity:\` mensagem \\- Faz uma pergunta usando o modelo perplexity\\.ai
 \\- \`search:\` mensagem \\- Faz uma pergunta usando o modelo perplexity\\.ai
 \\- \`reasonSearch:\` mensagem \\- Faz uma pergunta usando o modelo perplexity\\.ai com o uso de __Deepseek\\-R1__
@@ -120,6 +123,7 @@ export const adminHelpMessage = `*Comandos inline*:
  */
 export const userHelpMessage = `*Comandos inline*:
 \\- \`phind:\` mensagem \\- Faz uma pergunta usando o modelo __Phind__ com acesso web
+\\- \`isou:\` mensagem \\- Faz uma pergunta usando o modelo __Isou__ com acesso web
 \\- \`oss:\` mensagem \\- Faz uma pergunta usando o modelo de codigo aberto__GPT OSS 120b__
 \\- \`gpt:\` mensagem \\- Gera texto com __GPT 5 mini__
 \\- \`llama:\` mensagem \\- Gera texto com o __Llama 4 Maverick__

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -74,7 +74,7 @@ export const openWebUiModels = {
 	grok: 'pplx.grok-4-search',
 	o3: 'pplx.o3-search',
 	sonnetThinking: 'pplx.claude-4.0-sonnet-think-search',
-}
+};
 
 /**
  * Type definitions
@@ -103,7 +103,8 @@ export type ModelCommand =
 	| '/pplxo3'
 	| '/pplxclaude'
 	| '/polli'
-	| '/polliReasoning';
+	| '/polliReasoning'
+	| '/isou';
 
 /**
  * Available model commands
@@ -133,6 +134,7 @@ export const modelCommands: ModelCommand[] = [
 	'/pplxclaude',
 	'/polli',
 	'/polliReasoning',
+	'/isou',
 ];
 
 export const WHITELISTED_MODELS: ModelCommand[] = [
@@ -149,4 +151,5 @@ export const WHITELISTED_MODELS: ModelCommand[] = [
 	'/phind',
 	'/polli',
 	'/polliReasoning',
+	'/isou',
 ];

--- a/src/handlers/IsouHandler.ts
+++ b/src/handlers/IsouHandler.ts
@@ -1,0 +1,32 @@
+import { Context } from 'grammy-context';
+import isouService from '@/service/IsouService.ts';
+
+/**
+ * Handles requests for Isou models
+ * @param ctx - Telegram context
+ * @param commandMessage - Optional command message override
+ */
+export async function handleIsou(
+	ctx: Context,
+	commandMessage?: string,
+): Promise<void> {
+	const { userKey, contextMessage, photos, caption, quote } = await ctx
+		.extractContextKeys();
+
+	const message = commandMessage || contextMessage;
+
+	if (photos && caption) {
+		ctx.replyWithVisionNotSupportedByModel();
+		return;
+	}
+
+	const command = message!.split(':')[0].toLowerCase();
+
+	const { reader, onComplete, responseMap } = await isouService.generateText(
+		userKey,
+		quote,
+		message!.replace(`${command}:`, ''),
+	);
+
+	ctx.streamReply(reader, onComplete, responseMap);
+}

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -10,3 +10,4 @@ export { handleGithubCopilot } from './GithubCopilotHandler.ts';
 export { handlePhind } from './PhindHandler.ts';
 export { handleOpenWebUI } from './OpenWebUIHandler.ts';
 export { handlePollinations } from './PollinationsHandler.ts';
+export { handleIsou } from './IsouHandler.ts';

--- a/src/service/IsouService.ts
+++ b/src/service/IsouService.ts
@@ -1,0 +1,120 @@
+import { addContentToChatHistory, getChatHistory } from '@/repository/ChatRepository.ts';
+import { StreamReplyResponse } from '@/util/ChatConfigUtil.ts';
+
+const requestHeaders = {
+	'Content-Type': 'application/json',
+	'Accept': '*/*',
+	'Accept-Language': 'en-US,en;q=0.5',
+	'Referer': 'https://isou.chat/search',
+	'Origin': 'https://isou.chat',
+	'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:127.0) Gecko/20100101 Firefox/127.0',
+};
+
+const defaultModel = 'deepseek-ai/DeepSeek-R1-Distill-Qwen-32B';
+
+export default {
+	async generateText(
+		userKey: string,
+		quote: string = '',
+		prompt: string,
+		model: string = defaultModel,
+	): Promise<StreamReplyResponse> {
+		const geminiHistory = await getChatHistory(userKey);
+
+		const requestPrompt = quote ? `quote: "${quote}"\n\n${prompt}` : prompt;
+
+		const payload = {
+			stream: true,
+			model,
+			provider: 'siliconflow',
+			mode: 'deep',
+			language: 'all',
+			categories: ['science'],
+			engine: 'SEARXNG',
+			locally: false,
+			reload: false,
+		};
+
+		const query = encodeURIComponent(requestPrompt);
+		const url = `https://isou.chat/api/search?q=${query}`;
+
+		const response = await fetch(url, {
+			method: 'POST',
+			headers: requestHeaders,
+			body: JSON.stringify(payload),
+		});
+
+		if (!response.ok) {
+			throw new Error(`Failed to generate text: ${response.statusText}`);
+		}
+
+		const reader = response.body!.getReader();
+
+		const onComplete = (completedAnswer: string) =>
+			addContentToChatHistory(
+				geminiHistory,
+				quote,
+				requestPrompt,
+				completedAnswer,
+				userKey,
+			);
+
+		return { reader, onComplete, responseMap };
+	},
+};
+
+interface OuterData {
+	data: string;
+}
+interface ContextInfo {
+	name: string;
+	url: string;
+	id: number;
+}
+interface InnerData {
+	content?: string;
+	reasoningContent?: string;
+	context?: ContextInfo;
+}
+
+function responseMap(responseBody: string): string {
+	const lines = responseBody.split('\n');
+	let result = '';
+
+	for (const line of lines) {
+		const trimmed = line.trim();
+		if (!trimmed.startsWith('data:')) continue;
+
+		const jsonPart = trimmed.replace(/^data:\s*/, '');
+
+		let outer: OuterData;
+		try {
+			outer = JSON.parse(jsonPart);
+		} catch {
+			continue;
+		}
+
+		let inner: InnerData;
+		try {
+			inner = JSON.parse(outer.data);
+		} catch {
+			continue;
+		}
+
+		if (inner.context) {
+			result += `${inner.context.id}. Name: ${inner.context.name}, Source: ${inner.context.url}\n`;
+			continue;
+		}
+
+		if (inner.reasoningContent) {
+			result += inner.reasoningContent;
+			continue;
+		}
+
+		if (inner.content) {
+			result += inner.content;
+		}
+	}
+
+	return result;
+}

--- a/src/service/TelegramService.ts
+++ b/src/service/TelegramService.ts
@@ -11,13 +11,14 @@ import {
 	handleDuckDuckGo,
 	handleGemini,
 	handleGithubCopilot,
+	handleIsou,
 	handleOpenAI,
 	handleOpenRouter,
+	handleOpenWebUI,
 	handlePerplexity,
 	handlePhind,
-	handlePuter,
-	handleOpenWebUI,
 	handlePollinations,
+	handlePuter,
 } from '@/handlers/index.ts';
 
 import { FileUtils } from '@/util/FileUtils.ts';
@@ -103,7 +104,6 @@ export default {
 			});
 	},
 
-
 	/**
 	 * Retrieves and sends GitHub Copilot usage information to the user if the user is an admin.
 	 * @param ctx - The Telegram context.
@@ -151,10 +151,9 @@ Interações Premium:
 • *Overage permitido*: ${premium?.overage_permitted ? 'Sim' : 'Não'}
 • *Contador de overage*: ${premium?.overage_count ?? 0}`;
 
-			ctx.reply(formatted, {parse_mode: 'Markdown'})
+			ctx.reply(formatted, { parse_mode: 'Markdown' });
 		}
 	},
-
 
 	/**
 	 * Returns admin IDs if the requesting user is an admin
@@ -211,7 +210,7 @@ Interações Premium:
 			'/gpt5': () => handleGithubCopilot(ctx, `gpt5: ${message}`),
 			'/perplexity': () => handlePerplexity(ctx, `perplexity: ${message}`),
 			'/perplexityReasoning': () => handlePerplexity(ctx, `perplexityReasoning: ${message}`),
-			'/oss' : () => handleCloudflare(ctx, `oss: ${message}`),
+			'/oss': () => handleCloudflare(ctx, `oss: ${message}`),
 			'/llama': () => handleOpenRouter(ctx, `llama: ${message!}`),
 			// '/r1': () => handleBlackbox(ctx, `r1: ${message}`),
 			// '/r1online': () => handleBlackbox(ctx, `r1online: ${message}`),
@@ -224,6 +223,7 @@ Interações Premium:
 			'/o4mini': () => handleGithubCopilot(ctx, `o4mini: ${message}`),
 			// '/grok': () => handleBlackbox(ctx, `grok: ${message}`),
 			'/phind': () => handlePhind(ctx, `phind: ${message}`),
+			'/isou': () => handleIsou(ctx, `isou: ${message}`),
 			'/pplxgpt': () => handleOpenWebUI(ctx, `pgpt: ${message}`),
 			'/pplxgrok': () => handleOpenWebUI(ctx, `pgrok: ${message}`),
 			'/pplxclaude': () => handleOpenWebUI(ctx, `pclaude: ${message}`),
@@ -279,6 +279,10 @@ Interações Premium:
 		return handlePhind(ctx, commandMessage);
 	},
 
+	callIsouModel(ctx: Context, commandMessage?: string): Promise<void> {
+		return handleIsou(ctx, commandMessage);
+	},
+
 	callOpenWebUIModel(ctx: Context, commandMessage?: string): Promise<void> {
 		return handleOpenWebUI(ctx, commandMessage);
 	},
@@ -315,7 +319,7 @@ export async function textToSpeech(
  * Retrieves Copilot usage information if the requesting user is an admin.
  * @param ctx - Telegram context.
  * @returns A promise that resolves to the Copilot usage data or an empty object if not authorized.
-	 */
+ */
 export async function getUsage() {
 	const url = 'https://api.github.com/copilot_internal/user';
 	const headers: Record<string, string> = {
@@ -331,7 +335,11 @@ export async function getUsage() {
 	const text = await res.text();
 	if (!res.ok) {
 		let body: any;
-		try { body = JSON.parse(text); } catch { body = text; }
+		try {
+			body = JSON.parse(text);
+		} catch {
+			body = text;
+		}
 		throw new Error(`Copilot API error ${res.status}: ${JSON.stringify(body)}`);
 	}
 


### PR DESCRIPTION
## Summary
- add IsouService and handler for isou.chat search
- wire new `/isou` command into Telegram service, bot routing, and model config
- extend keyboards and help text to expose new provider

## Testing
- `./run_tests.sh` *(fails: Import 'https://deno.land/std@0.210.0/assert/mod.ts' failed: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_68af191c108083339f5897a236ed7024