### PR TITLE
feat: add user memory tool

### DIFF
--- a/src/prototype/ContextExtensionPrototype.ts
+++ b/src/prototype/ContextExtensionPrototype.ts
@@ -1,6 +1,7 @@
 import { Context } from 'grammy';
 import { Audio, Message, ParseMode, PhotoSize, Voice } from 'grammy-types';
 import { transcribeAudio } from '@/service/TelegramService.ts';
+import { setUserKey } from '@/utils/ExecutionContext.ts';
 
 const MARKDOWN_ERROR_MESSAGE = 'Error on markdown parse_mode, message:';
 
@@ -158,7 +159,7 @@ Context.prototype.streamReply = async function (
 	let sanitizedResult = result.removeThinkingChatCompletion()
 		.convertBlackBoxWebSearchSourcesToMarkdown();
 
-	if(sanitizedResult.length > 4093) {
+	if (sanitizedResult.length > 4093) {
 		const remainingChunk = sanitizedResult.substring(4093);
 		sanitizedResult = sanitizedResult.substring(0, 4093) + '...';
 		this.replyInChunks(remainingChunk);
@@ -181,6 +182,7 @@ Context.prototype.streamReply = async function (
 Context.prototype.extractContextKeys = async function (this: Context) {
 	const userId = this.from?.id!;
 	const userKey = `user:${userId}`;
+	setUserKey(userKey);
 	const audio = this.message?.voice || this.message?.audio;
 	const contextMessage = await getTextMessage(userId, userKey, this, audio);
 	const photos = this.message?.photo;

--- a/src/service/ToolService.ts
+++ b/src/service/ToolService.ts
@@ -1,6 +1,8 @@
 import OpenAi from 'npm:openai';
-import { XMLParser } from "npm:fast-xml-parser";
-import { parse } from "npm:node-html-parser";
+import { XMLParser } from 'npm:fast-xml-parser';
+import { parse } from 'npm:node-html-parser';
+import { getUserKey } from '@/utils/ExecutionContext.ts';
+import { adjustMemoryValue, clearMemory, getMemory, setMemory } from '@/repository/ChatRepository.ts';
 /**
  * Represents a search result from SearxNG.
  */
@@ -13,8 +15,8 @@ export interface SearxResult {
 }
 
 /**
-	* Represents a segment of a YouTube transcript.
-	*/
+ * Represents a segment of a YouTube transcript.
+ */
 interface YouTubeTranscriptSegment {
 	text: string;
 	startInMs: number;
@@ -27,6 +29,61 @@ export default class ToolService {
 	 */
 	// deno-lint-ignore ban-types
 	static tools = new Map<string, { schema: OpenAi.ChatCompletionTool; fn: Function }>([
+		['memory', {
+			schema: {
+				type: 'function',
+				function: {
+					name: 'memory',
+					description: 'Persist, recall, adjust or clear JSON memory for the current user',
+					parameters: {
+						type: 'object',
+						properties: {
+							operation: { type: 'string', enum: ['remember', 'recall', 'adjust', 'clear'] },
+							data: { type: 'object', additionalProperties: true },
+							field: { type: 'string' },
+							amount: { type: 'number' },
+						},
+						required: ['operation'],
+						additionalProperties: false,
+					},
+					strict: true,
+				},
+			},
+			/**
+			 * Handles memory operations for the current user.
+			 *
+			 * @param args - Memory parameters.
+			 * @param args.operation - Operation to perform.
+			 * @param args.data - JSON data to merge when remembering.
+			 * @param args.field - Field to adjust.
+			 * @param args.amount - Numeric adjustment.
+			 * @returns Result of the operation.
+			 * @throws An error if the user key is missing or parameters are invalid.
+			 */
+			fn: async (args: { operation: string; data?: Record<string, unknown>; field?: string; amount?: number }): Promise<any> => {
+				const userKey = getUserKey();
+				if (!userKey) throw new Error('userKey missing');
+				switch (args.operation) {
+                                        case 'remember':
+                                                if (
+                                                        !args.data ||
+                                                        typeof args.data !== 'object' ||
+                                                        Array.isArray(args.data)
+                                                ) throw new Error('invalid params');
+                                                return await setMemory(userKey, args.data);
+					case 'recall':
+						return await getMemory(userKey);
+					case 'adjust':
+						if (!args.field || typeof args.amount !== 'number') throw new Error('invalid params');
+						return await adjustMemoryValue(userKey, args.field, args.amount);
+					case 'clear':
+						await clearMemory(userKey);
+						return null;
+					default:
+						throw new Error('invalid operation');
+				}
+			},
+		}],
 		['search_searx', {
 			schema: {
 				type: 'function',
@@ -70,8 +127,7 @@ export default class ToolService {
 					'Pragma': 'no-cache',
 				};
 
-				const buildUrl = (baseUrl: string) =>
-					`${baseUrl}/search?${new URLSearchParams({ q: query, format: 'json', language: 'pt-BR' }).toString()}`;
+				const buildUrl = (baseUrl: string) => `${baseUrl}/search?${new URLSearchParams({ q: query, format: 'json', language: 'pt-BR' }).toString()}`;
 
 				const fetchJson = async (url: string) => {
 					const res = await fetch(url, { headers });
@@ -146,7 +202,7 @@ export default class ToolService {
 					const html = await response.text();
 					const root = parse(html);
 					try {
-						const body = root.getElementsByTagName("body")[0];
+						const body = root.getElementsByTagName('body')[0];
 						return body.children.filter((child) => child.tagName !== 'script')
 							.map((child) => child.text.trim().replace(/\s+/g, ' ')).join(' ');
 					} catch {
@@ -197,7 +253,11 @@ export default class ToolService {
 				const text = await res.text();
 				if (!res.ok) {
 					let body: any;
-					try { body = JSON.parse(text); } catch { body = text; }
+					try {
+						body = JSON.parse(text);
+					} catch {
+						body = text;
+					}
 					throw new Error(`Copilot API error ${res.status}: ${JSON.stringify(body)}`);
 				}
 
@@ -213,7 +273,8 @@ export default class ToolService {
 				type: 'function',
 				function: {
 					name: 'transcript_yt',
-					description: 'Busca a transcrição de um vídeo do YouTube a partir de sua URL., pode ser utilizado para responder perguntas sobre qualquer vídeo com "youtube" na URL',
+					description:
+						'Busca a transcrição de um vídeo do YouTube a partir de sua URL., pode ser utilizado para responder perguntas sobre qualquer vídeo com "youtube" na URL',
 					parameters: {
 						type: 'object',
 						properties: {
@@ -234,13 +295,13 @@ export default class ToolService {
 				},
 			},
 			/**
-			* Busca a transcrição de um vídeo do YouTube a partir de sua URL.
-			* pode ser utilizado para responder perguntas sobre qualquer vídeo com "youtube" na URL'
-			* @param args - Objeto contendo os parâmetros.
-			* @param args.videoUrl - A URL completa do vídeo do YouTube.
-			* @param args.preferredLanguages - (Opcional) Uma lista de códigos de idioma preferenciais (ex: ['pt-BR', 'en']).
-			* @returns Uma promessa que resolve para um array de objetos de transcrição ou null se a transcrição não for encontrada ou ocorrer um erro.
-			*/
+			 * Busca a transcrição de um vídeo do YouTube a partir de sua URL.
+			 * pode ser utilizado para responder perguntas sobre qualquer vídeo com "youtube" na URL'
+			 * @param args - Objeto contendo os parâmetros.
+			 * @param args.videoUrl - A URL completa do vídeo do YouTube.
+			 * @param args.preferredLanguages - (Opcional) Uma lista de códigos de idioma preferenciais (ex: ['pt-BR', 'en']).
+			 * @returns Uma promessa que resolve para um array de objetos de transcrição ou null se a transcrição não for encontrada ou ocorrer um erro.
+			 */
 			fn: async (args: { videoUrl: string; preferredLanguages?: string[] }): Promise<YouTubeTranscriptSegment[] | null> => {
 				const extractVideoId = (url: string): string | null => {
 					const match = url.match(/(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/(?:watch\?v=|embed\/|v\/)|youtu\.be\/)([\w-]{11})/);
@@ -257,7 +318,7 @@ export default class ToolService {
 				};
 				const chooseTrack = (tracks: any[], langs?: string[]): { url: string; lang: string } | null => {
 					for (const lang of langs || []) {
-						const t = tracks.find(t => t.languageCode.startsWith(lang) && t.baseUrl);
+						const t = tracks.find((t) => t.languageCode.startsWith(lang) && t.baseUrl);
 						if (t) return { url: `${t.baseUrl}&fmt=srv3`, lang: t.languageCode };
 					}
 					const first = tracks[0];
@@ -267,7 +328,7 @@ export default class ToolService {
 					const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '@_', trimValues: false });
 					const body = parser.parse(xml)?.timedtext?.body?.p || [];
 					const items = Array.isArray(body) ? body : [body];
-					return items.flatMap(p => {
+					return items.flatMap((p) => {
 						const start = Number(p['@_t'] || 0);
 						const duration = Number(p['@_d'] || 0);
 						const texts = p.s ? (Array.isArray(p.s) ? p.s : [p.s]).map((s: any) => typeof s === 'string' ? s : s['#text'] || '') : [p['#text'] || ''];
@@ -279,7 +340,7 @@ export default class ToolService {
 					if (!id) {
 						console.error('Invalid YouTube URL');
 						return null;
-					};
+					}
 					console.log(`Fetching video ID: ${id}`);
 					const html = await fetchText(args.videoUrl, { 'Accept-Language': 'en-US,en;q=0.9' });
 					const player = parsePlayerResponse(html);
@@ -287,20 +348,20 @@ export default class ToolService {
 					if (!tracks.length) {
 						console.error('No captions found');
 						return null;
-					};
-					console.debug('tracks url:', tracks.map(t => ({[t.languageCode]: t.baseUrl})))
+					}
+					console.debug('tracks url:', tracks.map((t) => ({ [t.languageCode]: t.baseUrl })));
 					const track = chooseTrack(tracks, args.preferredLanguages);
 					if (!track) {
 						console.error('No suitable track found');
 						return null;
-					};
+					}
 					const xml = await fetchText(track.url);
-					console.log('parsing segments from track url:', track.url, xml)
+					console.log('parsing segments from track url:', track.url, xml);
 					const segments = parseSegments(xml);
 					if (!segments.length) {
 						console.error('No segments found');
 						return null;
-					};
+					}
 					return segments;
 				} catch {
 					return null;

--- a/src/utils/ExecutionContext.ts
+++ b/src/utils/ExecutionContext.ts
@@ -1,0 +1,19 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+const store = new AsyncLocalStorage<{ userKey: string }>();
+
+/**
+ * Sets the user key for the current execution context.
+ * @param userKey User identifier
+ */
+export function setUserKey(userKey: string): void {
+	store.enterWith({ userKey });
+}
+
+/**
+ * Retrieves the user key from the current execution context.
+ * @returns The user key or undefined
+ */
+export function getUserKey(): string | undefined {
+	return store.getStore()?.userKey;
+}

--- a/tests/service/ToolServiceMemory.test.ts
+++ b/tests/service/ToolServiceMemory.test.ts
@@ -1,0 +1,35 @@
+import { assertEquals, assertRejects } from 'asserts';
+import { setUserKey } from '../../src/utils/ExecutionContext.ts';
+
+Deno.test('memory tool', async () => {
+	const originalOpenKv = Deno.openKv;
+	const store = new Map<string, string>();
+	const mockKv = {
+		get: (key: string[]) => Promise.resolve({ value: store.get(key.join('-')) }),
+		set: (key: string[], value: string) => {
+			store.set(key.join('-'), value);
+			return Promise.resolve();
+		},
+		delete: (key: string[]) => {
+			store.delete(key.join('-'));
+			return Promise.resolve();
+		},
+		close: () => Promise.resolve(),
+	} as unknown as Deno.Kv;
+	Deno.openKv = () => Promise.resolve(mockKv);
+	const ToolService = (await import('../../src/service/ToolService.ts')).default;
+	const tool = ToolService.tools.get('memory')?.fn as Function;
+	setUserKey('user:1');
+	await tool({ operation: 'remember', data: { debt: 500 } });
+	const recall = await tool({ operation: 'recall' });
+	assertEquals(recall, { debt: 500 });
+	const newValue = await tool({ operation: 'adjust', field: 'debt', amount: -100 });
+	assertEquals(newValue, 400);
+	const adjusted = await tool({ operation: 'recall' });
+	assertEquals(adjusted, { debt: 400 });
+        await tool({ operation: 'clear' });
+        const cleared = await tool({ operation: 'recall' });
+        assertEquals(cleared, {});
+        await assertRejects(() => tool({ operation: 'remember', data: 1 as unknown as Record<string, unknown> }));
+        Deno.openKv = originalOpenKv;
+});


### PR DESCRIPTION
## Summary
- allow memory tool to persist arbitrary JSON, with ChatRepository helpers to merge, adjust, and clear per-user memory
- compress stored memory and remove unused helper
- validate memory tool input to only accept JSON objects

## Testing
- `deno fmt src/repository/ChatRepository.ts src/service/ToolService.ts tests/service/ToolServiceMemory.test.ts` *(command not found: deno)*
- `deno task test` *(command not found: deno)*
- `curl -fsSL https://deno.land/install.sh | sh` *(error: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68af3f3488088333ab9804ada6d7af29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Novos Recursos
  - Memória por usuário: agora é possível “lembrar”, “recuperar”, “ajustar” valores e “limpar” dados persistentes por usuário.
  - Transcrições do YouTube incluem duração dos trechos, melhorando sincronização e uso em análises.

- Melhorias
  - Maior robustez no tratamento de erros e validações nas ferramentas.
  - Pequenos ajustes de consistência e formatação que tornam as respostas mais estáveis.

- Testes
  - Adicionada cobertura automatizada para as operações de memória (lembrar, recuperar, ajustar e limpar).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->