### PR TITLE
test: enforce model whitelist for users

### DIFF
--- a/tests/service/TelegramService.test.ts
+++ b/tests/service/TelegramService.test.ts
@@ -2,7 +2,7 @@ import { assertEquals } from 'asserts';
 import { spy } from 'mock';
 import { assertSpyCalls, createMockContext, MockContext, mockDenoEnv } from '../test_helpers.ts';
 
-import { ModelCommand } from '../../src/config/models.ts';
+import { ModelCommand, modelCommands, WHITELISTED_MODELS } from '../../src/config/models.ts';
 
 Deno.test('TelegramService', async (t) => {
 	mockDenoEnv({
@@ -17,7 +17,7 @@ Deno.test('TelegramService', async (t) => {
 	const originalOpenKv = Deno.openKv;
 	const mockKv = {
 		get: () => Promise.resolve({ value: '/gpt' }),
-		set: () => Promise.resolve({ ok: true }),
+		set: spy(() => Promise.resolve({ ok: true })),
 		delete: () => Promise.resolve({ ok: true }),
 		close: () => Promise.resolve(),
 	};
@@ -125,6 +125,25 @@ Deno.test('TelegramService', async (t) => {
 			ctx.reply.calls[0].args[0],
 			'Novo modelo de inteligência escolhido: /gpt',
 		);
+	});
+
+	await t.step('setCurrentModel should enforce whitelist for non-admin users', async () => {
+		const nonAdmin = 99999;
+		for (const model of WHITELISTED_MODELS) {
+			mockKv.set = spy(() => Promise.resolve({ ok: true }));
+			const ctx = createMockContext({ userId: nonAdmin, message: model });
+			await originalSetCurrentModel(ctx as any);
+			assertSpyCalls(mockKv.set, 1);
+			assertSpyCalls(ctx.reply, 1);
+		}
+		const disallowed = modelCommands.filter((m) => !WHITELISTED_MODELS.includes(m));
+		for (const model of disallowed) {
+			mockKv.set = spy(() => Promise.resolve({ ok: true }));
+			const ctx = createMockContext({ userId: nonAdmin, message: model });
+			await originalSetCurrentModel(ctx as any);
+			assertSpyCalls(mockKv.set, 0);
+			assertSpyCalls(ctx.reply, 0);
+		}
 	});
 
 	await t.step(

--- a/tests/service/TelegramService.test.ts
+++ b/tests/service/TelegramService.test.ts
@@ -2,7 +2,8 @@ import { assertEquals } from 'asserts';
 import { spy } from 'mock';
 import { assertSpyCalls, createMockContext, MockContext, mockDenoEnv } from '../test_helpers.ts';
 
-import { ModelCommand, modelCommands, WHITELISTED_MODELS } from '../../src/config/models.ts';
+import type { ModelCommand } from '../../src/config/models.ts';
+import { modelCommands, WHITELISTED_MODELS } from '../../src/config/models.ts';
 
 Deno.test('TelegramService', async (t) => {
 	mockDenoEnv({
@@ -129,12 +130,29 @@ Deno.test('TelegramService', async (t) => {
 
 	await t.step('setCurrentModel should enforce whitelist for non-admin users', async () => {
 		const nonAdmin = 99999;
+		assertEquals(
+			WHITELISTED_MODELS.every((m) => modelCommands.includes(m)),
+			true,
+			'WHITELISTED_MODELS deve ser subconjunto de modelCommands',
+		);
+		assertEquals(
+			new Set(WHITELISTED_MODELS).size,
+			WHITELISTED_MODELS.length,
+			'WHITELISTED_MODELS não deve conter duplicatas',
+		);
 		for (const model of WHITELISTED_MODELS) {
 			mockKv.set = spy(() => Promise.resolve({ ok: true }));
 			const ctx = createMockContext({ userId: nonAdmin, message: model });
 			await originalSetCurrentModel(ctx as any);
 			assertSpyCalls(mockKv.set, 1);
 			assertSpyCalls(ctx.reply, 1);
+			const expectedKey = [`user:${nonAdmin}`, 'current_model'];
+			assertEquals(mockKv.set.calls[0].args[0], expectedKey);
+			assertEquals(mockKv.set.calls[0].args[1], model);
+			assertEquals(
+				ctx.reply.calls[0].args[0],
+				`Novo modelo de inteligência escolhido: ${model}`,
+			);
 		}
 		const disallowed = modelCommands.filter((m) => !WHITELISTED_MODELS.includes(m));
 		for (const model of disallowed) {


### PR DESCRIPTION
## Summary
- add tests ensuring non-admin users can only set whitelisted models

## Testing
- `./run_tests.sh` *(fails: Import 'https://deno.land/std@0.210.0/assert/mod.ts' failed: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bc7d0c00833382e29073d72416e6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Ampliamos a cobertura para validar a aplicação da whitelist de modelos para usuários não administradores, garantindo aceitação apenas dos permitidos e bloqueio dos demais.
  - Melhoramos a observabilidade dos testes com contagem de chamadas em mocks para verificar efeitos colaterais.
  - Reorganizamos cenários de teste para maior clareza e assertividade nas validações.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->