### PR TITLE
feat: migrate to Deno.serve() with Oak JSR for new Deploy compatibility

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -17,7 +17,7 @@
 		"grammy-auto-chat-action": "https://deno.land/x/grammy_auto_chat_action@v0.1.1/mod.ts",
 		"grammy-auto-chat-action-types": "https://deno.land/x/grammy_auto_chat_action@v0.1.1/types.ts",
 		"grammy-types": "https://deno.land/x/grammy@v1.17.2/types.deno.ts",
-		"oak": "https://deno.land/x/oak@v12.6.1/mod.ts",
+		"oak": "jsr:@oak/oak",
 		"oak-cors": "https://deno.land/x/cors@v1.2.2/mod.ts",
 		"textcompress": "jsr:@lucasliet/textcompress",
 		"openai": "npm:openai@5.16.0",

--- a/main.ts
+++ b/main.ts
@@ -218,7 +218,11 @@ async function initializeApp() {
 		});
 
 		APP.use(webhookCallback(BOT, 'oak'));
-		APP.listen({ port: getPort() });
+		
+		Deno.serve(async (req) => {
+			const response = await APP.handle(req);
+			return response ?? new Response('Not Found', { status: 404 });
+		});
 	} else {
 		BOT.start();
 	}


### PR DESCRIPTION
- Update Oak to JSR version (jsr:@oak/oak) for better Deno 2.0 support
- Replace APP.listen() with Deno.serve() + APP.handle() pattern
- This approach should be compatible with new Deno Deploy warmup phase
- Maintains backward compatibility with Classic Deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Atualizada a infraestrutura do servidor HTTP para utilizar a runtime nativa, melhorando a compatibilidade e performance.
  * Modernizada a resolução de dependências para alinhar com padrões atuais de gerenciamento de módulos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->